### PR TITLE
feat: add install help modal with iOS/Android PWA instructions

### DIFF
--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useGame } from '../context/GameContext'
 import { useTranslation } from '../utils/i18n'
 import { ConfirmDialog } from './ui/ConfirmDialog'
+import { InstallHelpModal } from './ui/InstallHelpModal'
 import { LanguageSelector } from './ui/LanguageSelector'
 import { LicensesScreen } from './LicensesScreen'
 
@@ -9,6 +10,7 @@ export function HomeScreen() {
   const { state, dispatch } = useGame()
   const { t } = useTranslation()
   const [showConfirm, setShowConfirm] = useState(false)
+  const [showInstall, setShowInstall] = useState(false)
 
   const hasActiveGame = state.game !== null
   const [showLicenses, setShowLicenses] = useState(false)
@@ -70,8 +72,16 @@ export function HomeScreen() {
         />
       </div>
 
+      {/* Install link */}
+      <button
+        onClick={() => setShowInstall(true)}
+        className="mt-6 text-sm text-blue-500 underline"
+      >
+        {t.install.link}
+      </button>
+
       {/* Footer */}
-      <p className="mt-8 text-xs text-gray-400 text-center">
+      <p className="mt-4 text-xs text-gray-400 text-center">
         v{__APP_VERSION__} ·{' '}
         <button
           onClick={() => setShowLicenses(true)}
@@ -81,6 +91,9 @@ export function HomeScreen() {
         </button>{' '}
         · © 2026 jacobiz
       </p>
+
+      {/* Install help modal */}
+      {showInstall && <InstallHelpModal onClose={() => setShowInstall(false)} />}
 
       {/* Confirm dialog */}
       {showConfirm && (

--- a/src/components/ui/InstallHelpModal.tsx
+++ b/src/components/ui/InstallHelpModal.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from '../../utils/i18n'
+
+interface InstallHelpModalProps {
+  onClose: () => void
+}
+
+export function InstallHelpModal({ onClose }: InstallHelpModalProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center px-4">
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-sm max-h-[80dvh] overflow-y-auto flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-3">
+          <h2 className="text-lg font-bold text-gray-900">{t.install.title}</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="px-5 pb-5 flex flex-col gap-5">
+          {/* iOS */}
+          <section>
+            <h3 className="font-semibold text-gray-800 mb-2">{t.install.ios}</h3>
+            <ol className="list-decimal list-inside flex flex-col gap-1 text-sm text-gray-700">
+              <li>{t.install.iosStep1}</li>
+              <li>{t.install.iosStep2}</li>
+              <li>{t.install.iosStep3}</li>
+            </ol>
+          </section>
+
+          {/* Android */}
+          <section>
+            <h3 className="font-semibold text-gray-800 mb-2">{t.install.android}</h3>
+            <ol className="list-decimal list-inside flex flex-col gap-1 text-sm text-gray-700">
+              <li>{t.install.androidStep1}</li>
+              <li>{t.install.androidStep2}</li>
+            </ol>
+          </section>
+
+          {/* OK button */}
+          <button
+            onClick={onClose}
+            className="w-full py-3 rounded-xl bg-blue-500 text-white font-semibold active:bg-blue-600"
+          >
+            {t.common.ok}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -68,4 +68,15 @@ export const en: Messages = {
     copied: "Copied to clipboard",
     language: "Language",
   },
+  install: {
+    link: "📲 How to Install",
+    title: "How to Install",
+    ios: "iOS Safari",
+    iosStep1: "Tap the share button (□↑) at the bottom of the screen",
+    iosStep2: "Select \"Add to Home Screen\"",
+    iosStep3: "Tap \"Add\" in the top right",
+    android: "Android Chrome",
+    androidStep1: "Tap the ⋮ menu in the top right",
+    androidStep2: "Select \"Install app\" or \"Add to Home Screen\"",
+  },
 };

--- a/src/i18n/fi.ts
+++ b/src/i18n/fi.ts
@@ -65,4 +65,15 @@ export const fi: Messages = {
     copied: "Kopioitu leikepöydälle",
     language: "Kieli",
   },
+  install: {
+    link: "📲 Asennusohjeet",
+    title: "Asennusohjeet",
+    ios: "iOS Safari",
+    iosStep1: "Napauta jakamispainiketta (□↑) näytön alareunassa",
+    iosStep2: "Valitse \"Lisää kotinäytölle\"",
+    iosStep3: "Napauta \"Lisää\" oikeassa yläkulmassa",
+    android: "Android Chrome",
+    androidStep1: "Napauta ⋮ -valikkoa oikeassa yläkulmassa",
+    androidStep2: "Valitse \"Asenna sovellus\" tai \"Lisää kotinäytölle\"",
+  },
 }

--- a/src/i18n/ja.ts
+++ b/src/i18n/ja.ts
@@ -59,6 +59,17 @@ export const ja = {
     copied: "クリップボードにコピーしました",
     language: "言語",
   },
+  install: {
+    link: "📲 インストール方法",
+    title: "インストール方法",
+    ios: "iOS Safari",
+    iosStep1: "画面下の共有ボタン（□↑）をタップ",
+    iosStep2: "「ホーム画面に追加」を選ぶ",
+    iosStep3: "右上の「追加」をタップ",
+    android: "Android Chrome",
+    androidStep1: "右上の ⋮ メニューをタップ",
+    androidStep2: "「アプリをインストール」または「ホーム画面に追加」を選ぶ",
+  },
 };
 
 export type Messages = typeof ja;


### PR DESCRIPTION
## Summary

- ホーム画面に「📲 インストール方法」リンクを追加
- タップすると iOS Safari / Android Chrome のホーム画面追加手順をモーダルで表示
- 日本語・英語・フィンランド語の3言語対応

## Changes

- `src/i18n/ja.ts` / `en.ts` / `fi.ts` — `install` セクション追加（型定義含む）
- `src/components/ui/InstallHelpModal.tsx` — 新規モーダルコンポーネント
- `src/components/HomeScreen.tsx` — インストールリンクとモーダル状態を追加

## Test plan

- [x] `npm test` 27/27 passed
- [x] `npm run build` success
- [x] ブラウザで「インストール方法」リンクタップ → モーダル表示
- [x] ✕ ボタン / OK ボタンでモーダルが閉じる
- [x] 3言語切替でモーダル内テキストが切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)